### PR TITLE
feat: add release Taskfile include and OpenCode MCP config/docs

### DIFF
--- a/.ci/linters/.commitlintrc.json
+++ b/.ci/linters/.commitlintrc.json
@@ -1,3 +1,36 @@
 {
-  "extends": ["@hadenlabs/commitlint-config"]
+  "extends": ["@hadenlabs/commitlint-config"],
+  "parserPreset": {
+    "parserOpts": {
+      "headerPattern": "^(\\w+)\\s+(\\S+)\\s+\\(([^)]+)\\):\\s(.+)$",
+      "headerCorrespondence": ["type", "emoji", "scope", "subject"]
+    }
+  },
+  "rules": {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "hotfix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+        "sample",
+        "package",
+        "wip",
+        "deprecate",
+        "prompt"
+      ]
+    ],
+    "scope-enum": [2, "always", ["core", "accounts", "ci"]],
+    "subject-max-length": [2, "always", 100]
+  }
 }

--- a/.claude/skills/git-release/SKILL.md
+++ b/.claude/skills/git-release/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: git-release
+description: Create consistent releases and changelogs
+license: MIT
+---
+
+## What I do
+
+- Draft release notes from merged PRs
+- Propose a version bump
+- Provide a copy-pasteable `gh release create` command
+
+## When to use me
+
+Use this when preparing a tagged release. Ask clarifying questions if versioning scheme is unclear.
+
+## Process
+
+1. Run `task validate`
+2. Run `git log --oneline $(git describe --tags --abbrev=0)..HEAD`
+3. Categorise commits (features, fixes, chores)
+4. Determine version bump (major/minor/patch)
+5. Generate changelog entry
+6. Output the release command
+
+## PR template (when creating a PR)
+
+Use `.github/PULL_REQUEST_TEMPLATE.md` as the base for the PR body and fill it with the specifics of the change.
+
+Prefer to include:
+
+- Testing: `task validate`
+- Migration steps (if any)
+- Screenshots placeholders
+
+Example (copy/paste):
+
+```bash
+gh pr create --base main --head "${BRANCH}" \
+  --title "<title>" \
+  --body "$(cat <<'EOF'
+## Proposed changes
+
+<describe the big picture and link issues>
+
+Testing:
+- `task validate`
+
+Migration steps (if any):
+- None
+
+Screenshots:
+- [ ] N/A
+- [ ] <paste screenshot 1>
+
+## Types of changes
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](/docs/contributing.md) doc
+- [ ] Lint and unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Further comments
+
+<optional>
+EOF
+)"
+```

--- a/.claude/skills/goji-commit-smart/SKILL.md
+++ b/.claude/skills/goji-commit-smart/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: goji-commit-smart
+description: Create git commits using goji rules from .goji.json (type/scope/emoji/signoff) with path-based heuristics.
+license: MIT
+---
+
+# Goji Commit Smart Skill
+
+## Trigger phrases
+
+- "haz un commit goji"
+- "goji commit"
+- "commit smart"
+- "crea commits con goji"
+
+## Source of truth
+
+- `.goji.json`
+  - `types[]` (name + emoji)
+  - `scopes[]`
+  - `subjectmaxlength`
+  - `signoff`
+- `infobot.toml`
+  - `[issueTracking] provider + projectKey`
+  - `[issueTracking.branch]` extraction regexes (derive key/id from branch name)
+  - `[commit] style` (github|gitlab|jira)
+  - `[commit.providers.*]` rules
+
+## What I do
+
+- Run `task validate` before creating any commit.
+- Inspect working tree and staged changes.
+- Group changes into 1..N commits using path heuristics (avoid mixing unrelated areas).
+- Create commits following goji conventions: `<emoji> <type>(<scope>): <subject>`.
+- Derive issue key/id from the current branch name and inject it into the subject when required.
+- Create commits with `--signoff` when `signoff: true`.
+
+## Commit style (github|gitlab|jira)
+
+Decide commit style from `infobot.toml` `[commit].style`.
+
+- `jira`
+  - Require a Jira key in the subject (example: `AR-123`).
+  - Prefer: `<type>(<scope>): <JIRA-KEY> <subject>`.
+  - Derive `<JIRA-KEY>` from the current branch name using `infobot.toml` `[issueTracking].projectKey`.
+    - Default extraction: `(<PROJECTKEY>-[0-9]+)` when `[issueTracking.branch].jiraKeyFromProjectKey = true`.
+    - Override with `[issueTracking.branch].jiraKeyRegexOverride`.
+- `github`
+  - Allow referencing GitHub issues in the subject (example: `#123`).
+  - Optional commit body line: `Fixes #123`.
+  - Derive `123` from the current branch name using `infobot.toml` `[issueTracking.branch].githubIssueNumberRegex`.
+- `gitlab`
+  - Allow referencing GitLab issues in the subject (example: `#123`).
+  - Optional commit body line: `Closes #123`.
+  - Derive `123` from the current branch name using `infobot.toml` `[issueTracking.branch].gitlabIssueNumberRegex`.
+
+## Commit format
+
+- Title: `<emoji> <type>(<scope>): <subject>`
+  - `emoji` comes from `.goji.json` `types[].emoji` for the chosen type.
+  - `type` must be one of `.goji.json` `types[].name`.
+  - `scope` must be one of `.goji.json` `scopes[]`.
+  - `subject` length must be `<= subjectmaxlength`.
+
+Examples:
+
+- `📚 docs(ci): document MCP setup`
+- `👷 ci(ci): bump github actions runner`
+- `✨ feat(core): add release task include`
+
+## Heuristics (path -> type/scope)
+
+Use these as defaults; ask only when ambiguous.
+
+- `docs/**` -> `docs(ci)`
+- `.github/workflows/**` -> `ci(ci)`
+- `.claude/**` -> `chore(core)`
+- `.opencode/**` -> `prompt(core)`
+- `Taskfile.yml` -> `build(core)`
+- `data/**` -> `chore(core)` (or `sample(core)` if clearly examples)
+- `pkg/**` or `internal/**` or `core/**` or `config/**` -> `feat(core)` (or `fix(core)` if bug)
+
+If only formatting changes, prefer `style(core)`.
+If only refactors with no behavior change, prefer `refactor(core)`.
+
+## Process
+
+0) Validate first
+
+```bash
+task validate
+```
+
+- If `task validate` fails, do not commit. Fix issues, re-run `task validate`, then proceed.
+
+1) Collect context
+
+```bash
+git status --porcelain
+git diff
+git diff --cached
+git diff --name-only
+git diff --cached --name-only
+git rev-parse --abbrev-ref HEAD
+cat .goji.json
+cat infobot.toml
+```
+
+2) Derive issue key/id from branch
+
+- Determine `style` from `infobot.toml` `[commit].style`.
+- Parse the current branch name (`git rev-parse --abbrev-ref HEAD`) and extract:
+  - `jira`: `<PROJECTKEY>-<number>` (default derived from `[issueTracking].projectKey`)
+  - `github`/`gitlab`: `<number>`
+- If extraction fails (branch does not contain expected key/id), stop and ask the user for the key/id.
+
+3) Decide commit groups (intelligent split)
+
+- Prefer 1 commit if all changed files map to the same group.
+- Split into multiple commits when files span multiple groups, for example:
+  - docs-only vs CI-only vs code/tooling
+  - `.github/workflows/**` separate from `docs/**`
+  - `.claude/**` separate from runtime code
+
+Default grouping by path:
+
+- `docs/**` -> one commit
+- `.github/workflows/**` -> one commit
+- `.claude/**` + `provision/**` -> one commit
+- `.opencode/**` + `data/**` -> one commit
+- `Taskfile.yml` -> group with CI/tooling changes (not docs)
+- `pkg/**|internal/**|core/**|config/**` -> one commit
+
+4) Stage and commit each group
+
+- If there are already staged changes, commit them first as a single coherent group.
+- Otherwise, for each computed group, stage only those files:
+
+```bash
+git add <paths>
+```
+
+5) Draft commit title (use branch-derived key/id)
+
+- Choose `type/scope` from heuristics.
+- Pick `emoji` from `.goji.json` for that `type`.
+- Keep `<subject>` within `.goji.json` `subjectmaxlength`.
+- Subject rules by style:
+  - `jira`: include `<JIRA-KEY>` (e.g. `AR-123`) early in the subject.
+  - `github`/`gitlab`: include `#<number>` (e.g. `#123`) when relevant.
+
+6) Commit
+
+- If `.goji.json` `signoff` is `true`:
+
+```bash
+git commit -s -m "<emoji> <type>(<scope>): <subject>"
+```
+
+- Else:
+
+```bash
+git commit -m "<emoji> <type>(<scope>): <subject>"
+```
+
+7) Repeat for remaining groups until all intended commits are created.
+
+## Safety rules
+
+- Never commit secrets (examples: `.env`, `credentials.json`, private keys, tokens).
+- If any suspect files appear, stop and call them out.
+- Do not use `git commit --amend` unless explicitly requested.
+- Do not run destructive git commands (`reset --hard`, force-push) unless explicitly requested.

--- a/.claude/skills/goji-commit-smart/SKILL.md
+++ b/.claude/skills/goji-commit-smart/SKILL.md
@@ -31,7 +31,7 @@ license: MIT
 - Run `task validate` before creating any commit.
 - Inspect working tree and staged changes.
 - Group changes into 1..N commits using path heuristics (avoid mixing unrelated areas).
-- Create commits following goji conventions: `<emoji> <type>(<scope>): <subject>`.
+- Create commits following goji conventions: `<type>(<scope>): <emoji> <subject>`.
 - Derive issue key/id from the current branch name and inject it into the subject when required.
 - Create commits with `--signoff` when `signoff: true`.
 
@@ -46,27 +46,29 @@ Decide commit style from `infobot.toml` `[commit].style`.
     - Default extraction: `(<PROJECTKEY>-[0-9]+)` when `[issueTracking.branch].jiraKeyFromProjectKey = true`.
     - Override with `[issueTracking.branch].jiraKeyRegexOverride`.
 - `github`
-  - Allow referencing GitHub issues in the subject (example: `#123`).
+  - Allow referencing GitHub issues in the subject (example: `(#123)` at the end).
   - Optional commit body line: `Fixes #123`.
   - Derive `123` from the current branch name using `infobot.toml` `[issueTracking.branch].githubIssueNumberRegex`.
 - `gitlab`
-  - Allow referencing GitLab issues in the subject (example: `#123`).
+  - Allow referencing GitLab issues in the subject (example: `(#123)` at the end).
   - Optional commit body line: `Closes #123`.
   - Derive `123` from the current branch name using `infobot.toml` `[issueTracking.branch].gitlabIssueNumberRegex`.
 
 ## Commit format
 
-- Title: `<emoji> <type>(<scope>): <subject>`
+- Title: `<type>(<scope>): <emoji> <subject>`
   - `emoji` comes from `.goji.json` `types[].emoji` for the chosen type.
   - `type` must be one of `.goji.json` `types[].name`.
   - `scope` must be one of `.goji.json` `scopes[]`.
   - `subject` length must be `<= subjectmaxlength`.
 
+For `github`/`gitlab` styles, append the issue at the end of the subject: `(#<number>)`.
+
 Examples:
 
-- `📚 docs(ci): document MCP setup`
-- `👷 ci(ci): bump github actions runner`
-- `✨ feat(core): add release task include`
+- `docs(ci): 📚 document MCP setup (#123)`
+- `ci(ci): 👷 bump github actions runner (#123)`
+- `feat(core): ✨ add release task include (#123)`
 
 ## Heuristics (path -> type/scope)
 
@@ -75,7 +77,7 @@ Use these as defaults; ask only when ambiguous.
 - `docs/**` -> `docs(ci)`
 - `.github/workflows/**` -> `ci(ci)`
 - `.claude/**` -> `chore(core)`
-- `.opencode/**` -> `prompt(core)`
+- `.opencode/**` -> `chore(core)`
 - `Taskfile.yml` -> `build(core)`
 - `data/**` -> `chore(core)` (or `sample(core)` if clearly examples)
 - `pkg/**` or `internal/**` or `core/**` or `config/**` -> `feat(core)` (or `fix(core)` if bug)
@@ -147,20 +149,20 @@ git add <paths>
 - Keep `<subject>` within `.goji.json` `subjectmaxlength`.
 - Subject rules by style:
   - `jira`: include `<JIRA-KEY>` (e.g. `AR-123`) early in the subject.
-  - `github`/`gitlab`: include `#<number>` (e.g. `#123`) when relevant.
+  - `github`/`gitlab`: include `(#<number>)` (e.g. `(#123)`) at the end.
 
 6) Commit
 
 - If `.goji.json` `signoff` is `true`:
 
 ```bash
-git commit -s -m "<emoji> <type>(<scope>): <subject>"
+git commit -s -m "<type>(<scope>): <emoji> <subject>"
 ```
 
 - Else:
 
 ```bash
-git commit -m "<emoji> <type>(<scope>): <subject>"
+git commit -m "<type>(<scope>): <emoji> <subject>"
 ```
 
 7) Repeat for remaining groups until all intended commits are created.

--- a/.claude/skills/goji-commit-smart/SKILL.md
+++ b/.claude/skills/goji-commit-smart/SKILL.md
@@ -31,7 +31,7 @@ license: MIT
 - Run `task validate` before creating any commit.
 - Inspect working tree and staged changes.
 - Group changes into 1..N commits using path heuristics (avoid mixing unrelated areas).
-- Create commits following goji conventions: `<type>(<scope>): <emoji> <subject>`.
+- Create commits following goji conventions: `<type> <emoji> (<scope>): <subject>`.
 - Derive issue key/id from the current branch name and inject it into the subject when required.
 - Create commits with `--signoff` when `signoff: true`.
 
@@ -56,7 +56,7 @@ Decide commit style from `infobot.toml` `[commit].style`.
 
 ## Commit format
 
-- Title: `<type>(<scope>): <emoji> <subject>`
+- Title: `<type> <emoji> (<scope>): <subject>`
   - `emoji` comes from `.goji.json` `types[].emoji` for the chosen type.
   - `type` must be one of `.goji.json` `types[].name`.
   - `scope` must be one of `.goji.json` `scopes[]`.
@@ -66,9 +66,9 @@ For `github`/`gitlab` styles, append the issue at the end of the subject: `(#<nu
 
 Examples:
 
-- `docs(ci): 📚 document MCP setup (#123)`
-- `ci(ci): 👷 bump github actions runner (#123)`
-- `feat(core): ✨ add release task include (#123)`
+- `docs 📚 (ci): document MCP setup (#123)`
+- `ci 👷 (ci): bump github actions runner (#123)`
+- `feat ✨ (core): add release task include (#123)`
 
 ## Heuristics (path -> type/scope)
 
@@ -77,7 +77,7 @@ Use these as defaults; ask only when ambiguous.
 - `docs/**` -> `docs(ci)`
 - `.github/workflows/**` -> `ci(ci)`
 - `.claude/**` -> `chore(core)`
-- `.opencode/**` -> `chore(core)`
+- `.opencode/**` -> `prompt(core)`
 - `Taskfile.yml` -> `build(core)`
 - `data/**` -> `chore(core)` (or `sample(core)` if clearly examples)
 - `pkg/**` or `internal/**` or `core/**` or `config/**` -> `feat(core)` (or `fix(core)` if bug)
@@ -156,13 +156,13 @@ git add <paths>
 - If `.goji.json` `signoff` is `true`:
 
 ```bash
-git commit -s -m "<type>(<scope>): <emoji> <subject>"
+git commit -s -m "<type> <emoji> (<scope>): <subject>"
 ```
 
 - Else:
 
 ```bash
-git commit -m "<type>(<scope>): <emoji> <subject>"
+git commit -m "<type> <emoji> (<scope>): <subject>"
 ```
 
 7) Repeat for remaining groups until all intended commits are created.

--- a/.claude/skills/release/.openskills.json
+++ b/.claude/skills/release/.openskills.json
@@ -1,0 +1,7 @@
+{
+  "source": "https://gitlab.infosisglobal.com/architecture/skills.git",
+  "sourceType": "git",
+  "repoUrl": "https://gitlab.infosisglobal.com/architecture/skills.git",
+  "subpath": "skills/release",
+  "installedAt": "2026-03-08T10:49:34.129Z"
+}

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: release
+description: Run a release bump (major/minor/patch) and generate next changelog from the updated pyproject.toml version.
+license: MIT
+---
+
+# Release Skill
+
+## Trigger phrases
+
+- "haz un release:major"
+- "haz un release:minor"
+- "haz un release:patch"
+- "haz un release:pre_release"
+
+## Source of truth
+
+- `pyproject.toml` under `[project].version`
+
+## What to do
+
+- If the user requests `release:major`, run: `task release:major`
+- If the user requests `release:minor`, run: `task release:minor`
+- If the user requests `release:patch`, run: `task release:patch`
+- If the user requests `release:pre_release`, run: `task release:pre_release`
+
+## Expected result
+
+- Version is bumped (including `pyproject.toml`).
+- Next-tag changelog is generated with `APP_TAG` equal to the updated version.
+
+## Implementation detail
+
+- Always run: `task changelog:next APP_TAG=$(uv run bump-my-version show current_version)`

--- a/.claude/skills/update-pr/SKILL.md
+++ b/.claude/skills/update-pr/SKILL.md
@@ -49,7 +49,7 @@ EOF
 )"
 ```
 
-   - Fallback:
+- Fallback:
 
 ```bash
 gh pr edit <PR_NUMBER> --body "$(cat <<'EOF'

--- a/.claude/skills/update-pr/SKILL.md
+++ b/.claude/skills/update-pr/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: update-pr
+description: Push branch commits and update the existing PR body safely (prefer REST API)
+license: MIT
+---
+
+## What I do
+
+- Validate changes locally.
+- Push the current branch (handles unset upstream).
+- Detect the PR for the current branch.
+- Regenerate the PR body from `.github/PULL_REQUEST_TEMPLATE.md` using the current `main...HEAD` diff.
+- Update the PR body using GitHub REST API via `gh api` (fallback to `gh pr edit`).
+
+## When to use me
+
+Use this when you already have a PR open and need to refresh its description to match the latest branch changes.
+
+## Process
+
+1. Run `task validate`
+2. Collect context:
+   - `git diff main...HEAD --stat`
+   - `git diff main...HEAD`
+   - `git log main...HEAD --oneline`
+3. Push current branch:
+   - If upstream is not set: `git push -u origin HEAD`
+   - Otherwise: `git push`
+4. Detect PR:
+   - Prefer: `gh pr view --json number,url --jq '.number, .url'`
+   - Fallback: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number,url --jq '.[0].number, .[0].url'`
+5. Generate updated PR body (based on `.github/PULL_REQUEST_TEMPLATE.md`) and fill:
+   - Proposed changes: bullets derived from `main...HEAD` diff (group by area; reference key paths)
+   - Testing: include `task validate`
+   - Migration steps (if any)
+   - Screenshots placeholders
+   - Types of changes: mark what applies
+   - Checklist: mark what is true
+6. Update PR body:
+   - Prefer (REST, avoids GraphQL classic-projects failures):
+
+```bash
+owner="$(gh repo view --json owner --jq .owner.login)"
+repo="$(gh repo view --json name --jq .name)"
+gh api --method PATCH "repos/${owner}/${repo}/pulls/<PR_NUMBER>" \
+  -f body="$(cat <<'EOF'
+<filled template body>
+EOF
+)"
+```
+
+   - Fallback:
+
+```bash
+gh pr edit <PR_NUMBER> --body "$(cat <<'EOF'
+<filled template body>
+EOF
+)"
+```

--- a/.claude/skills/validate-pr/SKILL.md
+++ b/.claude/skills/validate-pr/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: validate-pr
+description: Find vulnerabilities or errors in a pull request (checks, scans, merge blockers) and propose fixes.
+license: MIT
+---
+
+## What I do
+
+- Ask which PR to validate (number or URL).
+- List PRs assigned to you so you can pick quickly.
+- Inspect CI/check failures, required checks, and merge blockers.
+- Look for security signals when available (Code Scanning / dependency updates).
+- Produce an actionable checklist to get the PR merge-ready.
+
+## First question (required)
+
+1. List PRs assigned to the current user:
+
+```bash
+gh pr list --assignee @me --state open --json number,title,url,headRefName,baseRefName,updatedAt --jq '.[] | "#\(.number)\t\(.headRefName) → \(.baseRefName)\t\(.updatedAt)\t\(.title)\t\(.url)"'
+```
+
+2. Ask: "Which PR do you want to validate? (number or URL)"
+
+Notes:
+- If the list is empty, fallback to:
+
+```bash
+gh pr list --author @me --state open --json number,title,url,headRefName,baseRefName,updatedAt --jq '.[] | "#\(.number)\t\(.headRefName) → \(.baseRefName)\t\(.updatedAt)\t\(.title)\t\(.url)"'
+```
+
+## Validation workflow (for PR <N>)
+
+### 1) Quick PR status
+
+```bash
+gh pr view <N> --json number,url,title,state,isDraft,mergeable,baseRefName,headRefName,author,reviewDecision,labels,assignees
+```
+
+### 2) Checks / CI failures
+
+```bash
+gh pr checks <N>
+```
+
+If there are failing runs, inspect logs:
+
+```bash
+branch="$(gh pr view <N> --json headRefName --jq .headRefName)"
+gh run list --branch "${branch}" --limit 10
+```
+
+Pick the failing run id and view:
+
+```bash
+gh run view <RUN_ID> --log-failed
+```
+
+### 3) Files changed (to scope the investigation)
+
+```bash
+gh pr diff <N> --stat
+```
+
+### 4) Security signals (best-effort)
+
+Code scanning alerts for the PR merge ref (may require permissions; can be empty):
+
+```bash
+owner="$(gh repo view --json owner --jq .owner.login)"
+repo="$(gh repo view --json name --jq .name)"
+gh api "repos/${owner}/${repo}/code-scanning/alerts?ref=refs/pull/<N>/merge&state=open" --jq '.[] | "\(.rule.id)\t\(.rule.severity)\t\(.state)\t\(.html_url)"'
+```
+
+If the API call returns 403/404, report that security alerts are not accessible with current permissions and continue with checks/logs.
+
+### 5) Output
+
+Provide:
+- The failing checks (name + link) and the root cause from logs.
+- Any merge blockers (conflicts, required reviews, missing approvals).
+- Any open code-scanning alerts (if accessible) with severity.
+- Concrete next steps (commands to run locally and files to change).

--- a/.github/workflows/confluence.yml
+++ b/.github/workflows/confluence.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   confluence:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out a copy of the repo
         if: ${{ !env.ACT }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         if: ${{ !env.ACT }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   sonar-scan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out a copy of the repo

--- a/.opencode/commands/goji-commit-smart.md
+++ b/.opencode/commands/goji-commit-smart.md
@@ -6,5 +6,5 @@ description: Run goji smart commit (task validate, group changes, derive key/id 
 2. Run smart commits for the current branch:
    - Always run `task validate` first
    - Group changes into 1..N commits
-   - Derive Jira key / issue id from the branch name (per `infobot.toml`)
+   - Derive issue key/id from the branch name (per `infobot.toml`)
    - Create commits using goji conventions and sign-off

--- a/.opencode/commands/goji-commit-smart.md
+++ b/.opencode/commands/goji-commit-smart.md
@@ -1,0 +1,10 @@
+---
+description: Run goji smart commit (task validate, group changes, derive key/id from branch, commit with goji)
+---
+
+1. Load skill: goji-commit-smart
+2. Run smart commits for the current branch:
+   - Always run `task validate` first
+   - Group changes into 1..N commits
+   - Derive Jira key / issue id from the branch name (per `infobot.toml`)
+   - Create commits using goji conventions and sign-off

--- a/.opencode/commands/prepare-pr.md
+++ b/.opencode/commands/prepare-pr.md
@@ -1,0 +1,13 @@
+---
+description: Prepare PR with description
+---
+
+1. Run `git diff main...HEAD --stat` to see changed files
+2. Run `git log main...HEAD --oneline` to see commits
+3. Load skill: git-release
+4. Generate a PR description with:
+   - Summary of changes
+   - Testing notes
+   - Migration steps (if any)
+   - Screenshots (suggest placeholders)
+5. Output the `gh pr create` command ready to paste

--- a/.opencode/commands/release.md
+++ b/.opencode/commands/release.md
@@ -1,0 +1,9 @@
+---
+description: Run a release bump using the release skill (major/minor/patch)
+---
+
+1. Load skill: release
+2. Read the bump type from `$1` (expected: `major`, `minor`, or `patch`)
+   - If `$1` is missing or not one of the expected values, ask the user to choose one of: `major` | `minor` | `patch`
+3. Run: `task release:$1`
+4. Confirm the new version and show the generated changelog entry (if produced by the task)

--- a/.opencode/commands/update-pr.md
+++ b/.opencode/commands/update-pr.md
@@ -12,7 +12,7 @@ description: Push branch commits and update PR content
    - Prefer: `gh pr view --json number,url --jq '.number, .url'`
    - Fallback: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number,url --jq '.[0].number, .[0].url'`
 6. Load skill: update-pr
-6. Generate an updated PR body using `.github/PULL_REQUEST_TEMPLATE.md` as the base, and fill in:
+7. Generate an updated PR body using `.github/PULL_REQUEST_TEMPLATE.md` as the base, and fill in:
    - Proposed changes (bullet list) derived from the _current_ branch changes:
      - Use `git diff main...HEAD --stat` + `git diff main...HEAD` to refresh the bullets with whatever is new
      - Add new bullets for newly introduced work; update/remove bullets that are no longer accurate
@@ -22,4 +22,4 @@ description: Push branch commits and update PR content
    - Screenshots placeholders
    - Types of changes (mark the right one)
    - Checklist (mark what is true)
-7. Update the PR content (follow the update-pr skill; prefer REST `gh api` and fallback to `gh pr edit`)
+8. Update the PR content (follow the update-pr skill; prefer REST `gh api` and fallback to `gh pr edit`)

--- a/.opencode/commands/update-pr.md
+++ b/.opencode/commands/update-pr.md
@@ -1,0 +1,25 @@
+---
+description: Push branch commits and update PR content
+---
+
+1. Run `task validate`
+2. Run `git diff main...HEAD --stat` to see changed files
+3. Run `git log main...HEAD --oneline` to see commits
+4. Push the current branch:
+   - If upstream is not set: `git push -u origin HEAD`
+   - Otherwise: `git push`
+5. Detect the PR for the current branch:
+   - Prefer: `gh pr view --json number,url --jq '.number, .url'`
+   - Fallback: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number,url --jq '.[0].number, .[0].url'`
+6. Generate an updated PR body using `.github/PULL_REQUEST_TEMPLATE.md` as the base, and fill in:
+   - Proposed changes (bullet list) derived from the _current_ branch changes:
+     - Use `git diff main...HEAD --stat` + `git diff main...HEAD` to refresh the bullets with whatever is new
+     - Add new bullets for newly introduced work; update/remove bullets that are no longer accurate
+     - Prefer grouping by area (e.g. Taskfile/docs/config) and reference key paths when helpful
+   - Testing: include `task validate`
+   - Migration steps (if any)
+   - Screenshots placeholders
+   - Types of changes (mark the right one)
+   - Checklist (mark what is true)
+7. Update the PR content:
+   - `gh pr edit <PR_NUMBER> --body "$(cat <<'EOF' <filled template body> EOF )"`

--- a/.opencode/commands/update-pr.md
+++ b/.opencode/commands/update-pr.md
@@ -11,6 +11,7 @@ description: Push branch commits and update PR content
 5. Detect the PR for the current branch:
    - Prefer: `gh pr view --json number,url --jq '.number, .url'`
    - Fallback: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number,url --jq '.[0].number, .[0].url'`
+6. Load skill: update-pr
 6. Generate an updated PR body using `.github/PULL_REQUEST_TEMPLATE.md` as the base, and fill in:
    - Proposed changes (bullet list) derived from the _current_ branch changes:
      - Use `git diff main...HEAD --stat` + `git diff main...HEAD` to refresh the bullets with whatever is new
@@ -21,5 +22,4 @@ description: Push branch commits and update PR content
    - Screenshots placeholders
    - Types of changes (mark the right one)
    - Checklist (mark what is true)
-7. Update the PR content:
-   - `gh pr edit <PR_NUMBER> --body "$(cat <<'EOF' <filled template body> EOF )"`
+7. Update the PR content (follow the update-pr skill; prefer REST `gh api` and fallback to `gh pr edit`)

--- a/.opencode/commands/validate-pr.md
+++ b/.opencode/commands/validate-pr.md
@@ -1,0 +1,6 @@
+---
+description: Validate a PR for errors/vulnerabilities (asks for PR; lists assigned PRs)
+---
+
+1. Load skill: validate-pr
+2. If `$1` is provided (PR number or URL), validate that PR; otherwise list PRs assigned to `@me` and ask which PR to validate.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,6 @@ repos:
       - id: requirements-txt-fixer
       - id: check-symlinks
       - id: file-contents-sorter
-      - id: fix-encoding-pragma
       - id: sort-simple-yaml
 
   - repo: https://github.com/tcort/markdown-link-check

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,6 +30,8 @@ includes:
     taskfile: "https://raw.githubusercontent.com/hadenlabs/tasks/refs/heads/main/src/docker/Taskfile.yml"
   version:
     taskfile: "https://raw.githubusercontent.com/hadenlabs/tasks/refs/heads/main/src/version/Taskfile.yml"
+  release:
+    taskfile: "https://raw.githubusercontent.com/hadenlabs/tasks/refs/heads/main/src/release/Taskfile.yml"
   plantuml:
     taskfile: "https://raw.githubusercontent.com/hadenlabs/tasks/refs/heads/main/src/plantuml/Taskfile.yml"
   prettier:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -88,6 +88,7 @@ vars:
   GOLANGCI_VERSION: 1.42.0
   TERRAFORM_VERSION: 1.11.4
   README_FILE: README.md
+  # NOTE: Agent workflow conventions live in `infobot.toml`.
   GIT_IGNORES_CUSTOM: |
     bin
     .project
@@ -195,6 +196,17 @@ tasks:
     desc: "Run validate on all files"
     cmds:
       - uv run pre-commit run --all-files
+
+  commit:guide:
+    desc: "Show commit style conventions (goji)"
+    silent: true
+    cmds:
+      - cmd: |
+          if [ ! -f "infobot.toml" ]; then
+            echo "Missing infobot.toml (required)" >&2
+            exit 1
+          fi
+          python provision/scripts/commit_guide.py
 
   help:
     cmds:

--- a/data/opencode/opencode.json
+++ b/data/opencode/opencode.json
@@ -1,9 +1,50 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "openai/gpt-5.2",
-  "small_model": "openai/gpt-4o-mini",
-  "instructions": ["AGENTS.md"],
+  "autoupdate": true,
+  "plugin": ["@franlol/opencode-md-table-formatter@0.0.3"],
   "mcp": {
+    "serena": {
+      "type": "local",
+      "command": ["uvx", "--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server"],
+      "enabled": true
+    },
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "enabled": true
+    },
+    "sequential-thinking": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-sequential-thinking"],
+      "enabled": true
+    },
+    "awslabs.aws-knowledge": {
+      "type": "remote",
+      "url": "https://knowledge-mcp.global.api.aws",
+      "enabled": false
+    },
+    "awslabs.aws-terraform": {
+      "type": "local",
+      "command": ["uvx", "awslabs.terraform-mcp-server@latest"],
+      "environment": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      },
+      "enabled": false
+    },
+    "hashicorp.terraform": {
+      "type": "local",
+      "command": ["docker", "run", "-i", "--rm", "hashicorp/terraform-mcp-server:latest"],
+      "enabled": true
+    },
+    "grafana": {
+      "type": "local",
+      "command": ["uvx", "mcp-grafana"],
+      "environment": {
+        "GRAFANA_URL": "{env:GRAFANA_URL}",
+        "GRAFANA_SERVICE_ACCOUNT_TOKEN": "{env:GRAFANA_SERVICE_ACCOUNT_TOKEN}"
+      },
+      "enabled": true
+    },
     "filesystem": {
       "type": "local",
       "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem"],
@@ -25,6 +66,185 @@
       "url": "{env:JIRA_MCP_URL}",
       "enabled": true,
       "oauth": {}
+    }
+  },
+  "provider": {
+    "openai": {
+      "name": "OpenAI",
+      "models": {
+        "gpt-5.2": {
+          "name": "GPT-5.2",
+          "limit": {
+            "context": 200000,
+            "output": 100000
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "gpt-5.1-codex": {
+          "name": "GPT-5.1 Codex",
+          "limit": {
+            "context": 200000,
+            "output": 100000
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "gpt-5.2-codex": {
+          "name": "GPT-5.2 Codex",
+          "limit": {
+            "context": 200000,
+            "output": 100000
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "gpt-5.1-codex-mini": {
+          "name": "GPT-5.1 Codex Mini",
+          "limit": {
+            "context": 200000,
+            "output": 65536
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "gpt-5.1-codex-max": {
+          "name": "GPT-5.1 Codex Max",
+          "limit": {
+            "context": 200000,
+            "output": 100000
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "gpt-4o": {
+          "name": "GPT-4o",
+          "limit": {
+            "context": 128000,
+            "output": 16384
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "gpt-4o-mini": {
+          "name": "GPT-4o Mini",
+          "limit": {
+            "context": 128000,
+            "output": 16384
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "gpt-4-turbo": {
+          "name": "GPT-4 Turbo",
+          "limit": {
+            "context": 128000,
+            "output": 4096
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "gpt-4": {
+          "name": "GPT-4",
+          "limit": {
+            "context": 8192,
+            "output": 4096
+          },
+          "modalities": {
+            "input": ["text"],
+            "output": ["text"]
+          }
+        },
+        "gpt-3.5-turbo": {
+          "name": "GPT-3.5 Turbo",
+          "limit": {
+            "context": 16385,
+            "output": 4096
+          },
+          "modalities": {
+            "input": ["text"],
+            "output": ["text"]
+          }
+        },
+        "o1": {
+          "name": "o1",
+          "limit": {
+            "context": 200000,
+            "output": 100000
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "o1-mini": {
+          "name": "o1 Mini",
+          "limit": {
+            "context": 128000,
+            "output": 65536
+          },
+          "modalities": {
+            "input": ["text"],
+            "output": ["text"]
+          }
+        },
+        "o1-preview": {
+          "name": "o1 Preview",
+          "limit": {
+            "context": 128000,
+            "output": 32768
+          },
+          "modalities": {
+            "input": ["text"],
+            "output": ["text"]
+          }
+        },
+        "o3": {
+          "name": "o3",
+          "limit": {
+            "context": 200000,
+            "output": 100000
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "o3-mini": {
+          "name": "o3 Mini",
+          "limit": {
+            "context": 200000,
+            "output": 100000
+          },
+          "modalities": {
+            "input": ["text"],
+            "output": ["text"]
+          }
+        }
+      },
+      "options": {
+        "reasoningEffort": "medium",
+        "reasoningSummary": "auto",
+        "textVerbosity": "medium",
+        "include": ["reasoning.encrypted_content"],
+        "store": false
+      }
     }
   }
 }

--- a/data/opencode/opencode.json
+++ b/data/opencode/opencode.json
@@ -2,6 +2,9 @@
   "$schema": "https://opencode.ai/config.json",
   "autoupdate": true,
   "plugin": ["@franlol/opencode-md-table-formatter@0.0.3"],
+  "model": "openai/gpt-5.2",
+  "small_model": "openai/gpt-4o-mini",
+  "instructions": ["AGENTS.md"],
   "mcp": {
     "serena": {
       "type": "local",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -354,7 +354,7 @@ Accepted format:
 Optional (if your tooling supports it):
 
 ```text
-<emoji> <type>(<scope>): <subject>
+<type>(<scope>): <emoji> <subject>
 ```
 
 Rules:
@@ -362,6 +362,7 @@ Rules:
 - Subject max length: 100 characters
 - Use one of the allowed scopes: `core`, `accounts`, `ci`
 - Sign-off is required (use `git commit -s` or ensure your commit tool adds it)
+- For GitHub/GitLab issue references, append the issue at the end: `(#123)`
 
 Types:
 
@@ -401,13 +402,13 @@ Types:
 
 Examples:
 
-- feat(core): IN-698 add opencode MCP docs
-- fix(core): IN-698 handle missing env var
+- feat(core): add opencode MCP docs (#123)
+- fix(core): handle missing env var (#123)
 - docs(core): update usage guide
 - refactor(core): extract install helper
 - style(core): format shell scripts
 - test(core): add coverage for patterns sync
-- ci(ci): run workflows on ubuntu-24.04
+- ci(ci): run workflows on ubuntu-24.04 (#123)
 - chore(core): bump action versions
 
 **Keep it short and simple!**

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -348,13 +348,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) to 
 Accepted format:
 
 ```text
-<type>(<scope>): <subject>
-```
-
-Optional (if your tooling supports it):
-
-```text
-<type>(<scope>): <emoji> <subject>
+<type> <emoji> (<scope>): <subject>
 ```
 
 Rules:
@@ -402,13 +396,13 @@ Types:
 
 Examples:
 
-- feat(core): add opencode MCP docs (#123)
-- fix(core): handle missing env var (#123)
+- feat ✨ (core): add opencode MCP docs (#123)
+- fix 🐛 (core): handle missing env var (#123)
 - docs(core): update usage guide
 - refactor(core): extract install helper
 - style(core): format shell scripts
 - test(core): add coverage for patterns sync
-- ci(ci): run workflows on ubuntu-24.04 (#123)
+- ci 👷 (ci): run workflows on ubuntu-24.04 (#123)
 - chore(core): bump action versions
 
 **Keep it short and simple!**

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -343,31 +343,72 @@ Your commit messages should serve these 3 important purposes:
 - To provide the least amount of necessary documentation
 - To help the future maintainers.
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) to make `git log`{.interpreted-text role="command"} a little easier to follow. We use commitlint enforcing conventional commits (See more [here](https://github.com/conventional-changelog/commitlint))
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) to make `git log`{.interpreted-text role="command"} easier to follow. We use commitlint to enforce the format (See [commitlint](https://github.com/conventional-changelog/commitlint)).
 
-**chore**: something just needs to happen, e.g. versioning
+Accepted format:
 
-**docs**: documentation pages in `docs/` or docstrings
+```text
+<type>(<scope>): <subject>
+```
 
-**feat**: new code in `./`
+Optional (if your tooling supports it):
 
-**fix**: code improvement in `./`
+```text
+<emoji> <type>(<scope>): <subject>
+```
 
-**refactor**: code movement in `./`
+Rules:
 
-**style**: aesthetic changes
+- Subject max length: 100 characters
+- Use one of the allowed scopes: `core`, `accounts`, `ci`
+- Sign-off is required (use `git commit -s` or ensure your commit tool adds it)
 
-**test**: test case modifications in `test/`
+Types:
 
-Examples commit messages:
+**feat**: introduce a new feature
 
-- chore: IN-698 implement model devices
-- docs: IN-698 implement configuration settings
-- feat: IN-698 create lambda function
-- fix: IN-698 retry upload on failure
-- refactor: IN-698 extract duplicate code
-- style: IN-698 format files python
-- test: IN-698 coverage around add permissions
+**fix**: fix a bug
+
+**docs**: documentation-only change
+
+**refactor**: code restructure without behavior change
+
+**style**: formatting/linting/aesthetic changes (no behavior change)
+
+**test**: add or update tests
+
+**chore**: maintenance tasks (versioning, deps bumps, tooling)
+
+**ci**: CI configuration and pipelines
+
+**build**: build scripts/config
+
+**perf**: performance improvements
+
+**hotfix**: critical production fix
+
+**deprecate**: remove dead code / mark as deprecated
+
+**package**: add/update compiled artifacts or packages
+
+**sample**: add/update samples/examples
+
+**prompt**: add/update prompts (PDD/Fabric)
+
+**revert**: revert a previous change
+
+**wip**: work in progress (avoid merging to `main`)
+
+Examples:
+
+- feat(core): IN-698 add opencode MCP docs
+- fix(core): IN-698 handle missing env var
+- docs(core): update usage guide
+- refactor(core): extract install helper
+- style(core): format shell scripts
+- test(core): add coverage for patterns sync
+- ci(ci): run workflows on ubuntu-24.04
+- chore(core): bump action versions
 
 **Keep it short and simple!**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,6 @@
 # Welcome to zsh-ai documentation
+
+- Project usage: `docs/usage.md`
+- Function reference: `docs/functions.md`
+- Environment variables: `docs/env-vars.md`
+- OpenCode MCP servers: `docs/mcp.md`

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,120 @@
+# MCP servers (OpenCode)
+
+This document describes the MCP (Model Context Protocol) servers configured in OpenCode and what each one is used for.
+
+## Overview
+
+| MCP id | Type | Purpose | Enabled | Requirements |
+| --- | --- | --- | :-: | --- |
+| `serena` | local | Code indexing/navigation and repo-local automations (via Serena) | yes | `uvx` + Python |
+| `context7` | remote | On-demand, versioned documentation (Context7) | yes | internet access |
+| `sequential-thinking` | local | Step-by-step reasoning tools (sequential-thinking MCP server) | yes | `npx`/Node |
+| `awslabs.aws-knowledge` | remote | AWS knowledge (knowledge MCP) | no | internet access |
+| `awslabs.aws-terraform` | local | Terraform assistance (awslabs terraform-mcp-server) | no | `uvx` + Python |
+| `hashicorp.terraform` | local | Terraform assistance via official HashiCorp container | yes | `docker` |
+| `grafana` | local | Grafana queries and operations | yes | `uvx` + `GRAFANA_*` env vars |
+| `filesystem` | local | Filesystem read/write (scoped by `ROOT`) | yes | `npx`/Node |
+| `github` | local | GitHub API access (issues/PRs/repos) | yes | `npx`/Node + `GITHUB_PERSONAL_ACCESS_TOKEN` |
+| `jira` | remote | Jira access via remote MCP | yes | `JIRA_MCP_URL` + OAuth (per your gateway) |
+
+## Server details
+
+### `serena`
+
+- Type: local
+- How it runs: `uvx --from git+https://github.com/oraios/serena serena start-mcp-server`
+- What it does: exposes MCP tools to work with the local repository (for example: understand project structure, navigate symbols/files, and perform server-assisted actions).
+- Requirements:
+  - `uvx` (UV) and a Python runtime.
+- Notes:
+  - As a local server, it inherits the permissions of the user running it.
+
+### `context7`
+
+- Type: remote
+- URL: `https://mcp.context7.com/mcp`
+- What it does: provides up-to-date, on-demand documentation for libraries/frameworks (useful for current API examples).
+- Requirements: internet connectivity.
+
+### `sequential-thinking`
+
+- Type: local
+- How it runs: `npx -y @modelcontextprotocol/server-sequential-thinking`
+- What it does: provides MCP tools aimed at breaking problems down and reasoning in steps; typically used for planning/analysis before code changes.
+- Requirements:
+  - Node.js + `npx`.
+
+### `awslabs.aws-knowledge` (disabled)
+
+- Type: remote
+- URL: `https://knowledge-mcp.global.api.aws`
+- What it does: access to AWS knowledge/documentation via an MCP endpoint.
+- Status: `enabled: false`.
+
+### `awslabs.aws-terraform` (disabled)
+
+- Type: local
+- How it runs: `uvx awslabs.terraform-mcp-server@latest`
+- What it does: Terraform-focused MCP tools (analysis/help with configurations, patterns, etc.).
+- Status: `enabled: false`.
+- Environment:
+  - `FASTMCP_LOG_LEVEL=ERROR` (reduces log verbosity).
+
+### `hashicorp.terraform`
+
+- Type: local
+- How it runs: `docker run -i --rm hashicorp/terraform-mcp-server:latest`
+- What it does: HashiCorp's official MCP server for Terraform workflows (intended for Terraform-related queries/actions).
+- Requirements:
+  - Docker running locally.
+- Notes:
+  - Depending on integration, the container may need access to your workspace (volumes). Your current config does not mount volumes, so the server will not see local files unless the OpenCode launcher adds mounts.
+
+### `grafana`
+
+- Type: local
+- How it runs: `uvx mcp-grafana`
+- What it does: integrates MCP tools to query/administer Grafana (dashboards, datasources, alerts, etc. depending on server support).
+- Requirements:
+  - `uvx` (UV) + Python.
+  - Environment variables:
+    - `GRAFANA_URL`
+    - `GRAFANA_SERVICE_ACCOUNT_TOKEN`
+- Notes:
+  - The token should belong to a Service Account with the minimum required permissions.
+
+### `filesystem`
+
+- Type: local
+- How it runs: `npx -y @modelcontextprotocol/server-filesystem`
+- What it does: allows OpenCode to read/write files through MCP.
+- Environment:
+  - `ROOT=.` limits server access to the current directory (workspace) when launched.
+- Security notes:
+  - Keep `ROOT` as restricted as possible.
+
+### `github`
+
+- Type: local
+- How it runs: `npx -y @modelcontextprotocol/server-github`
+- What it does: MCP tools to interact with GitHub (repos, issues, PRs, comments, etc.).
+- Requirements:
+  - Node.js + `npx`.
+  - Environment variable `GITHUB_PERSONAL_ACCESS_TOKEN`.
+- Notes:
+  - Use a PAT with minimum scopes (for example, only `repo` if needed, or finer scopes if you use fine-grained tokens).
+
+### `jira`
+
+- Type: remote
+- URL: `{env:JIRA_MCP_URL}`
+- What it does: integrates Jira (issues, comments, transitions, etc.) via an MCP gateway.
+- Requirements:
+  - Environment variable `JIRA_MCP_URL`.
+  - OAuth configuration (depends on your provider/instance; your config shows `oauth: {}` as a placeholder).
+
+## Quick troubleshooting
+
+- If a local MCP server does not start, verify dependencies (`uvx`/Node/Docker as applicable).
+- If a remote MCP server fails, verify connectivity/network and the relevant `*_URL` variables.
+- If `github`/`grafana`/`jira` fail with 401/403, review tokens and permissions.

--- a/infobot.toml
+++ b/infobot.toml
@@ -1,0 +1,62 @@
+[scm]
+provider = "auto"
+flow = "auto"
+
+# Examples (derive issue id from branch name)
+#
+# Jira:
+# - Branch: feature/<PROJECTKEY>-123-add-mcp-docs
+# - Commit: ✨ feat(core): <PROJECTKEY>-123 add mcp docs
+#
+# GitHub:
+# - Branch: feature/123-add-mcp-docs
+# - Commit: 🐛 fix(core): #123 handle missing env var
+# - Optional body: Fixes #123
+#
+# GitLab:
+# - Branch: feature/123-add-mcp-docs
+# - Commit: 🧹 chore(core): #123 bump tooling
+# - Optional body: Closes #123
+
+[issueTracking]
+provider = "github"
+
+# Optional. If omitted, agents should derive as: ^<projectKey>-[0-9]+$
+# keyRegexOverride = "^AR-[0-9]+$"
+
+[issueTracking.branch]
+# Source for deriving the issue id/key. Agents should use the current git branch name.
+# Example command: git rev-parse --abbrev-ref HEAD
+source = "branch"
+
+# Jira: extract the first Jira key found in the branch name.
+# This must be derived dynamically from `[issueTracking].projectKey`.
+# If you need a custom pattern, set `jiraKeyRegexOverride`.
+jiraKeyFromProjectKey = true
+jiraKeyRegexOverride = ""
+
+# GitHub/GitLab: extract the first issue number found in the branch name.
+# Recommended branch patterns:
+# - feature/123-short-desc
+# - bugfix/123-short-desc
+githubIssueNumberRegex = "(?:^|/)([0-9]+)(?:-|$)"
+gitlabIssueNumberRegex = "(?:^|/)([0-9]+)(?:-|$)"
+
+[commit]
+tool = "goji"
+format = "<emoji> <type>(<scope>): <subject>"
+style = "github"
+signoff = true
+subjectMaxLength = 100
+
+[commit.providers.github]
+issueRegex = "^#[0-9]+"
+closingBodyLine = "Fixes #<number>"
+
+[commit.providers.gitlab]
+issueRegex = "^#[0-9]+"
+closingBodyLine = "Closes #<number>"
+
+[commit.providers.jira]
+# Optional. If omitted, agents should derive as: ^<projectKey>-[0-9]+$
+# keyRegexOverride = "^AR-[0-9]+$"

--- a/infobot.toml
+++ b/infobot.toml
@@ -10,12 +10,12 @@ flow = "auto"
 #
 # GitHub:
 # - Branch: feature/123-add-mcp-docs
-# - Commit: fix(core): 🐛 handle missing env var (#123)
+# - Commit: fix 🐛 (core): handle missing env var (#123)
 # - Optional body: Fixes #123
 #
 # GitLab:
 # - Branch: feature/123-add-mcp-docs
-# - Commit: chore(core): 🧹 bump tooling (#123)
+# - Commit: chore 🧹 (core): bump tooling (#123)
 # - Optional body: Closes #123
 
 [issueTracking]
@@ -44,7 +44,7 @@ gitlabIssueNumberRegex = "(?:^|/)([0-9]+)(?:-|$)"
 
 [commit]
 tool = "goji"
-format = "<type>(<scope>): <emoji> <subject>"
+format = "<type> <emoji> (<scope>): <subject>"
 style = "github"
 signoff = true
 subjectMaxLength = 100

--- a/infobot.toml
+++ b/infobot.toml
@@ -10,12 +10,12 @@ flow = "auto"
 #
 # GitHub:
 # - Branch: feature/123-add-mcp-docs
-# - Commit: 🐛 fix(core): #123 handle missing env var
+# - Commit: fix(core): 🐛 handle missing env var (#123)
 # - Optional body: Fixes #123
 #
 # GitLab:
 # - Branch: feature/123-add-mcp-docs
-# - Commit: 🧹 chore(core): #123 bump tooling
+# - Commit: chore(core): 🧹 bump tooling (#123)
 # - Optional body: Closes #123
 
 [issueTracking]
@@ -44,17 +44,17 @@ gitlabIssueNumberRegex = "(?:^|/)([0-9]+)(?:-|$)"
 
 [commit]
 tool = "goji"
-format = "<emoji> <type>(<scope>): <subject>"
+format = "<type>(<scope>): <emoji> <subject>"
 style = "github"
 signoff = true
 subjectMaxLength = 100
 
 [commit.providers.github]
-issueRegex = "^#[0-9]+"
+issueRegex = "\\(#[0-9]+\\)$"
 closingBodyLine = "Fixes #<number>"
 
 [commit.providers.gitlab]
-issueRegex = "^#[0-9]+"
+issueRegex = "\\(#[0-9]+\\)$"
 closingBodyLine = "Closes #<number>"
 
 [commit.providers.jira]

--- a/provision/scripts/commit_guide.py
+++ b/provision/scripts/commit_guide.py
@@ -59,7 +59,7 @@ def main():
         print(f"- Regex: {rx}")
         print(f"- Branch extract regex: {brx}")
         print("- Branch example: feature/123-short-desc")
-        print("- Example: fix(core): handle missing env var (#123)")
+        print("- Example: fix 🐛 (core): handle missing env var (#123)")
         print("- Optional body line: Fixes #123")
         return 0
 
@@ -70,7 +70,7 @@ def main():
         print(f"- Regex: {rx}")
         print(f"- Branch extract regex: {brx}")
         print("- Branch example: feature/123-short-desc")
-        print("- Example: fix(core): handle missing env var (#123)")
+        print("- Example: fix 🐛 (core): handle missing env var (#123)")
         print("- Optional body line: Closes #123")
         return 0
 

--- a/provision/scripts/commit_guide.py
+++ b/provision/scripts/commit_guide.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import sys
+
+
+def _read_toml(path):
+    try:
+        import tomllib  # py3.11+
+    except ModuleNotFoundError:
+        print("Python 3.11+ is required (tomllib missing)", file=sys.stderr)
+        raise
+
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def main():
+    cfg = _read_toml("infobot.toml")
+
+    commit = cfg.get("commit", {})
+    issue = cfg.get("issueTracking", {})
+    issue_branch = issue.get("branch", {}) if isinstance(issue.get("branch", {}), dict) else {}
+    providers = (commit.get("providers", {}) if isinstance(commit.get("providers", {}), dict) else {})
+
+    style = commit.get("style", "jira")
+    fmt = commit.get("format", "<emoji> <type>(<scope>): <subject>")
+    signoff = bool(commit.get("signoff", True))
+
+    print("Commit tool: goji (.goji.json)")
+    print("Agent config: infobot.toml")
+    print(f"Commit style: {style}")
+    print(f"Format: {fmt}")
+    print(f"Sign-off: {'required' if signoff else 'optional'}")
+    print("")
+
+    if style == "jira":
+        key = issue.get("projectKey", "AR")
+        rx = (issue.get("keyRegexOverride", "") or "").strip() or f"^{key}-[0-9]+$"
+        brx_override = (issue_branch.get("jiraKeyRegexOverride", "") or "").strip()
+        brx_from_key = bool(issue_branch.get("jiraKeyFromProjectKey", True))
+        if brx_override:
+            brx = brx_override
+        elif brx_from_key:
+            brx = f"({key}-[0-9]+)"
+        else:
+            brx = "([A-Z][A-Z0-9]+-[0-9]+)"
+        print("Jira style: subject must include a Jira key")
+        print(f"- Project key: {key}")
+        print(f"- Regex: {rx}")
+        print(f"- Branch extract regex: {brx}")
+        print(f"- Branch example: feature/{key}-123-short-desc")
+        print(f"- Example: feat(core): {key}-123 add opencode MCP docs")
+        return 0
+
+    if style == "github":
+        rx = providers.get("github", {}).get("issueRegex", "^#[0-9]+")
+        brx = issue_branch.get("githubIssueNumberRegex", "(?:^|/)([0-9]+)(?:-|$)")
+        print("GitHub style: subject may reference an issue number")
+        print(f"- Regex: {rx}")
+        print(f"- Branch extract regex: {brx}")
+        print("- Branch example: feature/123-short-desc")
+        print("- Example: fix(core): #123 handle missing env var")
+        print("- Optional body line: Fixes #123")
+        return 0
+
+    if style == "gitlab":
+        rx = providers.get("gitlab", {}).get("issueRegex", "^#[0-9]+")
+        brx = issue_branch.get("gitlabIssueNumberRegex", "(?:^|/)([0-9]+)(?:-|$)")
+        print("GitLab style: subject may reference an issue number")
+        print(f"- Regex: {rx}")
+        print(f"- Branch extract regex: {brx}")
+        print("- Branch example: feature/123-short-desc")
+        print("- Example: fix(core): #123 handle missing env var")
+        print("- Optional body line: Closes #123")
+        return 0
+
+    print("Unknown commit.style (supported: github|gitlab|jira)", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/provision/scripts/commit_guide.py
+++ b/provision/scripts/commit_guide.py
@@ -53,24 +53,24 @@ def main():
         return 0
 
     if style == "github":
-        rx = providers.get("github", {}).get("issueRegex", "^#[0-9]+")
+        rx = providers.get("github", {}).get("issueRegex", "\\(#[0-9]+\\)$")
         brx = issue_branch.get("githubIssueNumberRegex", "(?:^|/)([0-9]+)(?:-|$)")
         print("GitHub style: subject may reference an issue number")
         print(f"- Regex: {rx}")
         print(f"- Branch extract regex: {brx}")
         print("- Branch example: feature/123-short-desc")
-        print("- Example: fix(core): #123 handle missing env var")
+        print("- Example: fix(core): handle missing env var (#123)")
         print("- Optional body line: Fixes #123")
         return 0
 
     if style == "gitlab":
-        rx = providers.get("gitlab", {}).get("issueRegex", "^#[0-9]+")
+        rx = providers.get("gitlab", {}).get("issueRegex", "\\(#[0-9]+\\)$")
         brx = issue_branch.get("gitlabIssueNumberRegex", "(?:^|/)([0-9]+)(?:-|$)")
         print("GitLab style: subject may reference an issue number")
         print(f"- Regex: {rx}")
         print(f"- Branch extract regex: {brx}")
         print("- Branch example: feature/123-short-desc")
-        print("- Example: fix(core): #123 handle missing env var")
+        print("- Example: fix(core): handle missing env var (#123)")
         print("- Optional body line: Closes #123")
         return 0
 


### PR DESCRIPTION
## Proposed changes

This PR improves the OpenCode/agent workflow for `zsh-ai` and standardizes commit conventions driven by `infobot.toml`. Related to (#12).

- CI: bump GitHub Actions runners to ubuntu-24.04 in `.github/workflows/confluence.yml`, `.github/workflows/lint.yml`, `.github/workflows/sonarqube.yml`.
- Commit conventions: add `infobot.toml` and update commit format to `<type> <emoji> (<scope>): <subject>` with GitHub/GitLab issue suffix `(#<number>)`.
- Developer tooling: add `task commit:guide` in `Taskfile.yml` and `provision/scripts/commit_guide.py` to print the active commit style.
- Commitlint: teach commitlint to parse the new header format via `.ci/linters/.commitlintrc.json`.
- Pre-commit: remove the deprecated `fix-encoding-pragma` hook from `.pre-commit-config.yaml`.
- OpenCode: extend `data/opencode/opencode.json` with MCP servers and provider model metadata/options.
- Docs: add MCP server documentation in `docs/mcp.md` and link it from `docs/index.md`; update `docs/contributing.md` with the new commit format.
- Skills/commands: add `.claude/skills/*` and `.opencode/commands/*` helpers for common workflows (goji smart commits, validate PR, update PR, release).

Testing:
- `task validate`

Migration steps (if any):
- If you create commits locally, switch to the new format defined in `infobot.toml`:
  - `<type> <emoji> (<scope>): <subject> (#<number>)` for GitHub/GitLab.
  - See `task commit:guide` for the current rules.

Screenshots:
- [ ] N/A
- [ ] <paste screenshot 1>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/docs/contributing.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

- None.